### PR TITLE
Add config file

### DIFF
--- a/OctoPrintConfiguration.py
+++ b/OctoPrintConfiguration.py
@@ -1,0 +1,161 @@
+#   Copyright 2015 Scott Hraban
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+__copyright__ = "Copyright (C) 2015 Scott Hraban - Released under terms of the Apache License, Version 2.0"
+
+import os
+import json
+import uuid
+
+from Cura.util.profile import getBasePath
+
+class OctoPrintPrinter(object):
+
+	def __init__(self, name, scheme, host, port, path, apiKey = None, key = None):
+		super(OctoPrintPrinter, self).__init__()
+		
+		self._config = {"key": key or uuid.uuid4(),
+						"name": name or "OctoPrint Printer",
+						"scheme": scheme or "http",
+						"host": host or "localhost",
+						"port": port or 5000,
+						"path": path or "",
+						"apiKey": apiKey or "" }
+	
+	def getKey(self):
+		return self._config.get("key")
+		
+	def setKey(self, value):
+		self._config["key"] = value
+		
+	def getName(self):
+		return self._config.get("name")
+		
+	def setName(self, value):
+		self._config["name"] = value
+		
+	def getScheme(self):
+		return self._config.get("scheme")
+		
+	def setScheme(self, value):
+		self._config["scheme"] = value
+		
+	def getHost(self):
+		return self._config.get("host")
+		
+	def setHost(self, value):
+		self._config["host"] = value
+		
+	def getPort(self):
+		return self._config.get("port")
+		
+	def setPort(self, value):
+		self._config["port"] = value
+		
+	def getPath(self):
+		return self._config.get("path")
+		
+	def setPath(self, value):
+		self._config["path"] = value
+		
+	def getApiKey(self):
+		return self._config.get("apiKey")
+		
+	def setApiKey(self, value):
+		self._config["apiKey"] = value
+		
+	def getConfig(self):
+		return self._config
+
+		
+class OctoPrintConfiguration(object):
+
+	def __init__(self):
+		super(OctoPrintConfiguration, self).__init__()
+
+		self._config = None
+		self._configFileDate = None
+		
+		if not os.path.exists(self._getConfigFilePath()):
+			self._createDefaultConfig()
+			self._writeConfigToFile()
+		else:
+			self._readConfigFromFile()
+			
+	def getDiscovery(self):
+		return self._config.get("discovery")
+		
+	def setDiscover(self, discovery):
+		self._config["discovery"] = discovery
+		
+	def getPrinters(self):
+		printers = []
+		for key in (self._config.get("printers") or {}).keys():
+			if not key == "auto-generated-uuid":
+				config = self._config.get("printers").get(key)
+				printers.append(OctoPrintPrinter(config["name"], config["scheme"], config["host"], config["port"], config["path"], config["apiKey"], config["key"]))
+		return printers
+		
+	def updatePrinter(self, printer):
+		key = printer.getKey() or uuid.uuid4()
+		printer.setKey(key)
+		printers = self._config.get("printers")
+		if printers is None:
+			printers = {}
+			self._config["printers"] = printers
+		printers[key] = printer.getConfig()
+		
+		self._writeConfigToFile()
+
+	def updateConfigFromFile(self):
+		actualConfigFileDate = os.path.getmtime(self._getConfigFilePath())
+		if actualConfigFileDate > self._configFileDate:
+			self._readConfigFromFile()
+			return True
+		else:
+			return False
+	
+	def _readConfigFromFile(self):
+		self._config = json.loads(open(self._getConfigFilePath()).read())
+
+		self._updateConfigFileDate()
+			
+	def _writeConfigToFile(self):
+		config = open(self._getConfigFilePath(), "w")
+		config.write(json.dumps(self._config, indent=4))
+		config.close()
+		
+		self._updateConfigFileDate()
+		
+	def _updateConfigFileDate(self):
+		self._configFileDate = os.path.getmtime(self._getConfigFilePath())
+	
+	def _createDefaultConfig(self):
+		self._config = {}
+		
+		self._config["printers"] = []
+		
+		self._config["printers"] = {}
+		self._config["printers"]["auto-generated-uuid"] = { "key" : "auto-generated-uuid",
+															"scheme": "https",
+															"host": "127.0.0.1",
+															"port": 5000,
+															"path": "",
+															"name": "OctoPrint Example",
+															"apiKey": "the-api-key"}
+
+		self._config["discovery"] = True
+
+	def _getConfigFilePath(self):
+		return os.path.join(getBasePath(), 'octoprint_configuration.json')
+

--- a/OctoPrintPrinterConnection.py
+++ b/OctoPrintPrinterConnection.py
@@ -37,7 +37,7 @@ class OctoPrintPrinterConnection(printerConnectionBase.printerConnectionBase):
 	Class to connect and print files with the OctoPrint
 	Auto-detects if the OctoPrint box is available and handles communication with the OctoPrint API
 	"""
-	def __init__(self, key, scheme, host, port, path, name, group):
+	def __init__(self, key, name, scheme, host, port, path, apiKey, group):
 		super(OctoPrintPrinterConnection, self).__init__(name)
 
 		print "{} Connection created: {}://{}:{}{}".format(name, scheme, host, port, path)
@@ -47,7 +47,8 @@ class OctoPrintPrinterConnection(printerConnectionBase.printerConnectionBase):
 		self._key = key
 
 		self._httpClient = OctoPrintHttpClient(scheme, host, port, path, "json")
-		self._httpClient.addHeader("X-Api-Key", "YOUR_API_KEY")
+		if apiKey:
+			self.setApiKey(apiKey)
 
 		self._isAvailable = False
 		self._printing = False
@@ -73,6 +74,9 @@ class OctoPrintPrinterConnection(printerConnectionBase.printerConnectionBase):
 		self.getApiKeyThread.start()
 
 
+	def setApiKey(self, apiKey):
+		self._httpClient.addHeader("X-Api-Key", apiKey)
+	
 	#Load the file into memory for printing.
 	def loadGCodeDataForFilename(self, dataStream, filename):
 		if self._printing:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,17 @@
 # octoprint-printer-connection-plugin-for-cura
 OctoPrint Printer Connection Plugin for Cura to allow direct printing from Cura to OctoPrint. In practice, this means that the Save icon will change to a WiFi looking icon, which when pressed will upload the gcode to your OctoPrint, and open a dialog, from which the Print button will actually start the print.
 
-At this point you need to manually enter the OctoPrint Api Key in the source code when you install - sub-optimal to say the least, but I have not had the time to get up to speed on Python GUI libraries. Ideally, when a OctoPrint instance is detected, a dialog would pop up (or maybe wait until actually trying to print) requesting the Api Key, which it would then store (after validation) into the Cura preferences for use next time. If anyone out there would like to contribute and/or give pointers on how one would do this, that would be much appreciated!
+This plugin stored its configuration in a file called octoprint_configuration.json in the same folder that Cura keeps its preferences. This file can be modified to manually add printers, turn auto discovery on/off, or to enter an API Key for an auto discovered printer.
+
+I have not had the time to get up to speed on Python GUI libraries, but ideally, when a OctoPrint instance is detected, a dialog would pop up (or maybe wait until actually trying to print) requesting the API Key, which it would then store (after validation) into the configuration file for use next time. If anyone out there would like to contribute and/or give pointers on how one would do this, that would be much appreciated!
 
 Installation
 ============
 1. Create a new directory in your Cura installation's plugin directory, the name does not matter, but recommended is "OctoPrintPrinterConnection".
-2. Edit the OctoPrintPrinterConnection.py file and search for the "addHeader" method call on the http client - change the line to use your OctoPrint Api Key.
-3. Enable [discovery](https://github.com/foosel/OctoPrint/wiki/Plugin:-Discovery) on OctoPrint, which currently requires running on OctoPrint's devel branch.
+2. Start Cura
+3. (optional) Enable [discovery](https://github.com/foosel/OctoPrint/wiki/Plugin:-Discovery) on OctoPrint, which currently requires running on OctoPrint's devel branch. Edit the octoprint_configuration to add the API Key to the entry created by auto discovery.
+4. (optional) Edit the octoprint_configuration.json file to manually add a printer that cannot be found using auto discovery.
+5. Wait a little while for the octoprint configuration file to be reloaded.
 
 Dependencies
 ============


### PR DESCRIPTION
Added storage of the configuration in an external configuration file.
1. Allows turning discovery on/off
2. Allows manually adding printers, rather than using auto discovery
3. Allows adding the API Key to the configuration for the printer, for printers added manually or discovered.
